### PR TITLE
Don't allow any arbitrary callable as a default

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,7 +3,6 @@ branch = True
 omit =
     *site-packages*
     setup.py
-    minique/cli.py
 
 [report]
 exclude_lines =

--- a/README.md
+++ b/README.md
@@ -39,9 +39,12 @@ job = get_job(redis, job_id)
 ### Worker(s)
 
 * Ensure your workers are able to import the functions you wish to run.
+* Set the callables the worker will allow with `--allow-callable`.
+  * Alternately, you may wish to subclass `minique.work.job_runner.JobRunner`
+    to specify an entirely different lookup mechanism.
 
 ```bash
-$ minique -u redis://localhost:6379/4 -q work -q anotherqueue -q thirdqueue
+$ minique -u redis://localhost:6379/4 -q work -q anotherqueue -q thirdqueue --allow-callable 'my_jobs.*'
 ```
 
 Todo

--- a/minique/cli.py
+++ b/minique/cli.py
@@ -5,15 +5,21 @@ from redis import StrictRedis
 
 from minique.work.worker import Worker
 
-parser = argparse.ArgumentParser()
-parser.add_argument("-u", "--redis-url", required=True)
-parser.add_argument("-q", "--queues", nargs="+", required=True)
+
+def get_parser():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-u", "--redis-url", required=True)
+    parser.add_argument("-q", "--queues", nargs="+", required=True)
+    parser.add_argument("--allow-callable", nargs="+", required=True)
+    return parser
 
 
 def main():
+    parser = get_parser()
     args = parser.parse_args()
     logging.basicConfig(datefmt="%Y-%m-%d %H:%M:%S", level=logging.INFO)
     redis = StrictRedis.from_url(args.redis_url)
     worker = Worker.for_queue_names(redis=redis, queue_names=args.queues)
+    worker.allowed_callable_patterns = set(args.allow_callable)
     worker.log.info("Worker initialized")
     worker.loop()

--- a/minique/cli.py
+++ b/minique/cli.py
@@ -11,15 +11,19 @@ def get_parser():
     parser.add_argument("-u", "--redis-url", required=True)
     parser.add_argument("-q", "--queues", nargs="+", required=True)
     parser.add_argument("--allow-callable", nargs="+", required=True)
+    parser.add_argument("--single-tick", action="store_true")
     return parser
 
 
-def main():
+def main(argv=None):
     parser = get_parser()
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
     logging.basicConfig(datefmt="%Y-%m-%d %H:%M:%S", level=logging.INFO)
     redis = StrictRedis.from_url(args.redis_url)
     worker = Worker.for_queue_names(redis=redis, queue_names=args.queues)
     worker.allowed_callable_patterns = set(args.allow_callable)
     worker.log.info("Worker initialized")
-    worker.loop()
+    if args.single_tick:
+        worker.tick()
+    else:
+        worker.loop()

--- a/minique/excs.py
+++ b/minique/excs.py
@@ -16,3 +16,7 @@ class AlreadyAcquired(InvalidStatus):
 
 class AlreadyResulted(InvalidStatus):
     pass
+
+
+class InvalidJob(ValueError):
+    pass

--- a/minique/work/worker.py
+++ b/minique/work/worker.py
@@ -15,6 +15,9 @@ class Worker:
     queue_timeout = 1
     job_runner_class = JobRunner
 
+    # This property may be ignored by subclasses, but it's here for convenience's sake.
+    allowed_callable_patterns = frozenset()
+
     def __init__(self, redis: Redis, queues: List[Queue]) -> None:
         self.id = self.compute_id()
         self.redis = redis

--- a/minique_tests/conftest.py
+++ b/minique_tests/conftest.py
@@ -11,11 +11,16 @@ def pytest_configure() -> None:
     logging.basicConfig(datefmt="%Y-%m-%d %H:%M:%S", level=logging.INFO)
 
 
-@pytest.fixture()
-def redis() -> Redis:
-    redis_url = os.environ.get("REDIS_URL")
-    if not redis_url:  # pragma: no cover
+@pytest.fixture(scope="session")
+def redis_url() -> str:
+    url = os.environ.get("REDIS_URL")
+    if not url:  # pragma: no cover
         pytest.skip("no REDIS_URL (required for redis fixture)")
+    return url
+
+
+@pytest.fixture()
+def redis(redis_url) -> Redis:
     return Redis.from_url(redis_url)
 
 

--- a/minique_tests/test_cli.py
+++ b/minique_tests/test_cli.py
@@ -1,0 +1,21 @@
+from minique.api import enqueue
+from minique.cli import main
+
+
+def test_cli(redis, redis_url, random_queue_name):
+    kwargs = {"a": 10, "b": 15}
+    job = enqueue(
+        redis, random_queue_name, "minique_tests.jobs.sum_positive_values", kwargs
+    )
+    main(
+        [
+            "-u",
+            redis_url,
+            "-q",
+            random_queue_name,
+            "--allow-callable",
+            "minique_tests.*",
+            "--single-tick",
+        ]
+    )
+    assert job.result == 25

--- a/minique_tests/test_customization.py
+++ b/minique_tests/test_customization.py
@@ -3,7 +3,7 @@ from redis import Redis
 
 from minique.api import enqueue
 from minique.work.job_runner import JobRunner
-from minique.work.worker import Worker
+from minique_tests.worker import TestWorker
 
 
 class HonkJobRunner(JobRunner):
@@ -14,7 +14,7 @@ class HonkJobRunner(JobRunner):
         print("Alarmed honk! {}".format(excinfo))
 
 
-class HonkWorker(Worker):
+class HonkWorker(TestWorker):
     job_runner_class = HonkJobRunner
 
 

--- a/minique_tests/worker.py
+++ b/minique_tests/worker.py
@@ -1,0 +1,8 @@
+from minique.work.worker import Worker
+
+
+class TestWorker(Worker):
+    __test__ = False
+    allowed_callable_patterns = {
+        "minique_tests.*",
+    }


### PR DESCRIPTION
While Minique 0.1.x is secure so long as a malicious party does not have direct access to the Redis server, this hardens things on the worker side.

Setting `Worker.allowed_callable_patterns` to `{'*'}` (or passing in `--allow-callable '*'` in the CLI) will emulate the 0.1.x behavior.