### PR TITLE
Allow custom data encodings

### DIFF
--- a/minique/encoding.py
+++ b/minique/encoding.py
@@ -1,0 +1,59 @@
+import json
+from typing import Union, Any
+
+registry = {}
+default_encoding_name = None
+
+
+def register_encoding(name, *, default=False):
+    def decorator(cls):
+        global default_encoding_name
+        registry[name] = cls
+        if default:
+            default_encoding_name = name
+        return cls
+
+    return decorator
+
+
+class BaseEncoding:
+    def encode(self, value: Any, failsafe: bool = False) -> Union[str, bytes]:
+        """
+        Encode a value to a string or bytes.
+
+        :param failsafe: When set, hint that the encoder should try hard not to fail,
+                         even if it requires loss of fidelity.
+        """
+        raise NotImplementedError("Encoding not implemented")
+
+    def decode(self, value: Union[str, bytes]) -> Any:
+        raise NotImplementedError("Decoding not implemented")
+
+
+@register_encoding("json", default=True)
+class JSONEncoding(BaseEncoding):
+    """
+    Default (JSON) encoding for kwargs and results.
+    """
+
+    # These can be effortlessly overridden in subclasses
+    dump_kwargs = {
+        "ensure_ascii": False,
+        "separators": (",", ":"),
+    }
+    load_kwargs = {}
+    failsafe_default = str
+
+    def encode(self, value: Any, failsafe: bool = False) -> Union[str, bytes]:
+        kwargs = self.dump_kwargs.copy()
+        if failsafe:
+            kwargs["default"] = self.failsafe_default
+        return json.dumps(
+            value,
+            **kwargs,
+        )
+
+    def decode(self, value: Union[str, bytes]) -> Any:
+        if isinstance(value, bytes):
+            value = value.decode()
+        return json.loads(value, **self.load_kwargs)

--- a/minique/utils/__init__.py
+++ b/minique/utils/__init__.py
@@ -1,4 +1,3 @@
-import json
 import random
 from contextlib import contextmanager
 from importlib import import_module
@@ -64,14 +63,3 @@ def get_random_pronounceable_string(length: int = 12) -> str:
         s.append(random.choice(consonants))
         s.append(random.choice(vowels) * random.choice((1, 1, 2)))
     return "".join(s)[:length]
-
-
-def get_json_or_none(value: bytes) -> Any:
-    """
-    If the value is truthy, decode it as JSON. Otherwise return None.
-    """
-    if value:
-        if isinstance(value, bytes):
-            value = value.decode()
-        return json.loads(str(value))
-    return None

--- a/minique_tests/jobs.py
+++ b/minique_tests/jobs.py
@@ -9,6 +9,10 @@ def sum_positive_values(a, b):
     return a + b
 
 
+def wrap_kwargs(**kwargs):
+    return dict(kwargs.copy())
+
+
 def job_with_unjsonable_retval() -> datetime.datetime:
     return datetime.datetime.now()
 

--- a/minique_tests/test_errors.py
+++ b/minique_tests/test_errors.py
@@ -1,5 +1,6 @@
 import sys
 import time
+import uuid
 
 import pytest
 from redis import Redis
@@ -22,6 +23,14 @@ def check_sentry_event_calls(sentry_event_calls, num_expected: int):
             assert any(  # pragma: no cover
                 call.args[0]["level"] == "error" for call in sentry_event_calls
             )
+
+
+def test_unjsonable_arg(redis: Redis, random_queue_name: str):
+    kwargs = {
+        "phooey": uuid.uuid4(),
+    }
+    with pytest.raises(TypeError):
+        enqueue(redis, random_queue_name, job_with_unjsonable_retval, kwargs)
 
 
 def test_unjsonable_retval(redis: Redis, random_queue_name: str, sentry_event_calls):

--- a/minique_tests/test_minique.py
+++ b/minique_tests/test_minique.py
@@ -21,6 +21,7 @@ def test_basics(redis: Redis, success: bool, random_queue_name: str) -> None:
     r_job = worker.tick()
     assert job == r_job  # we executed that particular job, right?
     for job in (job, get_job(redis, job.id)):
+        assert job.encoding_name == "json"
         assert job.has_finished
         assert job.acquisition_info["worker"] == worker.id
         assert job.duration > 0


### PR DESCRIPTION
This PR implements support for custom encoding classes that deal with serializing/deserializing the kwargs and results for jobs.

The defaults stay the same and everything is backwards compatible, but users registering custom encodings must make sure to have them registered similarly in the worker process.