### PR TITLE
🚮 Allow dequeue jobs without side-effects

### DIFF
--- a/minique/api.py
+++ b/minique/api.py
@@ -48,7 +48,10 @@ def enqueue(
     return job
 
 
-def get_job(redis: "Redis[bytes]", job_id: str) -> Job:
+def get_job(
+    redis: "Redis[bytes]",
+    job_id: str,
+) -> Job:
     job = Job(redis, job_id)
     job.ensure_exists()
     return job

--- a/minique/models/job.py
+++ b/minique/models/job.py
@@ -49,6 +49,13 @@ class Job:
             raise InvalidStatus(f"Job {self.id} has status {status}, will not enqueue")
         return self.get_queue().ensure_enqueued(self)
 
+    def dequeue(self) -> bool:
+        """
+        Remove the job from the queue without changing its status.
+        """
+        num_removed = self.redis.lrem(self.get_queue().redis_key, 0, self.id)
+        return num_removed > 0
+
     @property
     def redis_key(self) -> str:
         return f"{JOB_KEY_PREFIX}{self.id}"


### PR DESCRIPTION
This is one approach to avoid our queues getting infinitely larger on single job workers.

**... another approach that just came to mind is not to place the job key to queue and use the `Job` hash regardless :thinking:** 

but then we might need alternative way to get "incoming workload count" if we need that, probably won't :shrug: 

Discuss if you have opinions.

~Also includes minor bugfix (or well, couldn't find the code that would slam general Redis commands to instantiated pipeline), but can split / review this if we decide to go to the other route~ #34 

This was the path of least resistance :zap: 