### PR TITLE
📦️ Stored jobs

### DIFF
--- a/minique/api.py
+++ b/minique/api.py
@@ -35,34 +35,50 @@ def enqueue(
     :raises minique.excs.DuplicateJob: If a job with the same ID already exists.
     :raises minique.excs.NoSuchJob: If the job does not exist right after creation.
     """
-    if not encoding_name:
-        encoding_name = encoding.default_encoding_name
-    encoder = encoding.registry[str(encoding_name)]()
-
-    if not isinstance(callable, str):
-        callable = f"{callable.__module__}.{callable.__qualname__}"
-
-    if not job_id:
-        job_id = get_random_pronounceable_string()
-
-    job = Job(redis, job_id)
-    if job.exists:
-        raise DuplicateJob(f"duplicate job: {job_id}")
-
-    payload = {
-        "queue": queue_name,
-        "callable": str(callable),
-        "kwargs": encoder.encode(kwargs or {}),
-        "encoding_name": encoding_name,
-        "status": JobStatus.NONE.value,
-        "ctime": time.time(),
-        "job_ttl": int(job_ttl),
-        "result_ttl": int(result_ttl),
-    }
-    queue = Queue(redis, name=queue_name)
-    queue.enqueue_initial(job=job, payload=payload)
-    job.ensure_exists()
+    job = _define_and_store_job(
+        redis=redis,
+        callable=callable,
+        kwargs=kwargs,
+        job_id=job_id,
+        job_ttl=job_ttl,
+        result_ttl=result_ttl,
+        encoding_name=encoding_name,
+        queue_name=queue_name,
+    )
     return job
+
+
+def store(
+    redis: "Redis[bytes]",
+    callable: Union[Callable[..., Any], str],
+    kwargs: Optional[Dict[str, Any]] = None,
+    job_id: Optional[str] = None,
+    job_ttl: int = 0,
+    result_ttl: int = 86400 * 7,
+    encoding_name: Optional[str] = None,
+) -> Job:
+    """
+    Store callable as a job without placing it in the queue.
+
+    :param redis: Redis connection
+    :param callable: A dotted path to the callable to execute on the worker.
+    :param kwargs: Keyword arguments to pass to the callable.
+    :param job_id: An identifier for the job; defaults to a random string.
+    :param job_ttl: Time-to-live for the job in seconds; defaults to never expire.
+    :param result_ttl: Time-to-live for the result in seconds; defaults to 7 days.
+    :param encoding_name: Name of the encoding to use for the job payload; defaults to JSON.
+    :raises minique.excs.DuplicateJob: If a job with the same ID already exists.
+    :raises minique.excs.NoSuchJob: If the job does not exist right after creation.
+    """
+    return _define_and_store_job(
+        redis=redis,
+        callable=callable,
+        kwargs=kwargs,
+        job_id=job_id,
+        job_ttl=job_ttl,
+        result_ttl=result_ttl,
+        encoding_name=encoding_name,
+    )
 
 
 def get_job(
@@ -104,3 +120,53 @@ def cancel_job(
             p.execute()
         return True
     return False
+
+
+def _define_and_store_job(
+    *,
+    redis: "Redis[bytes]",
+    callable: Union[Callable[..., Any], str],
+    kwargs: Optional[Dict[str, Any]] = None,
+    job_id: Optional[str] = None,
+    job_ttl: int = 0,
+    result_ttl: int = 86400 * 7,
+    encoding_name: Optional[str] = None,
+    queue_name: Optional[str] = None,
+) -> Job:
+    if not encoding_name:
+        encoding_name = encoding.default_encoding_name
+    encoder = encoding.registry[str(encoding_name)]()
+
+    if not isinstance(callable, str):
+        callable = f"{callable.__module__}.{callable.__qualname__}"
+
+    if not job_id:
+        job_id = get_random_pronounceable_string()
+
+    job = Job(redis, job_id)
+    if job.exists:
+        raise DuplicateJob(f"duplicate job: {job_id}")
+
+    payload: Dict[str, Any] = {
+        "callable": str(callable),
+        "kwargs": encoder.encode(kwargs or {}),
+        "encoding_name": encoding_name,
+        "status": JobStatus.NONE.value,
+        "ctime": time.time(),
+        "job_ttl": int(job_ttl),
+        "result_ttl": int(result_ttl),
+    }
+    if queue_name:
+        payload["queue"] = queue_name
+
+    with redis.pipeline() as p:
+        p.hset(job.redis_key, mapping=payload)  # type: ignore[arg-type]
+        if payload["job_ttl"] > 0:
+            p.expire(job.redis_key, payload["job_ttl"])
+        if queue_name:
+            queue = Queue(redis, name=queue_name)
+            p.rpush(queue.redis_key, job.id)
+        p.execute()
+
+    job.ensure_exists()
+    return job

--- a/minique/models/queue.py
+++ b/minique/models/queue.py
@@ -30,15 +30,6 @@ class Queue:
         """
         return self.redis.delete(self.redis_key)
 
-    def enqueue_initial(self, job: "Job", payload: dict) -> None:  # type: ignore[type-arg]
-        assert payload["queue"] == self.name
-        with self.redis.pipeline() as p:
-            p.hset(job.redis_key, mapping=payload)
-            if payload["job_ttl"] > 0:
-                p.expire(job.redis_key, payload["job_ttl"])
-            p.rpush(self.redis_key, job.id)
-            p.execute()
-
     def get_queue_index(self, job: "Job") -> Optional[int]:
         # TODO: use `LPOS` (https://redis.io/commands/lpos/) when available for this
         job_id_bytes = str(job.id).encode()

--- a/minique/utils/__init__.py
+++ b/minique/utils/__init__.py
@@ -4,6 +4,7 @@ from importlib import import_module
 from threading import local
 from typing import TYPE_CHECKING, Any, Callable, Iterator, List, Optional
 
+
 if TYPE_CHECKING:
     from minique.models.job import Job
 


### PR DESCRIPTION
~some sneakier jobs~

this is an alternative approach to #33 

~then we can flag some jobs as `initialize_only` without affecting the queue~

~I was first thinking adding another function to `api` like `initialize()` but that would cause a bit of duplication, especially as the function takes so many arguments as it is :laughing:~

~thoughts? should it be a separate function?~ yes

adds `store()` to the public API to use as an alternative to `enqueue()`