### PR TITLE
Add priority queue support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
       - run: pip install build twine
       - run: python -m build .
       - run: twine check dist/*
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: build
           path: dist

--- a/minique/excs.py
+++ b/minique/excs.py
@@ -24,3 +24,7 @@ class InvalidJob(ValueError):
 
 class MissingJobData(ValueError):
     pass
+
+
+class Retry(Exception):
+    pass

--- a/minique/models/priority_queue.py
+++ b/minique/models/priority_queue.py
@@ -1,0 +1,138 @@
+from typing import TYPE_CHECKING
+
+from redis import Redis
+
+from minique.models.queue import Queue
+
+if TYPE_CHECKING:
+    from minique.models.job import Job
+
+
+ADD_JOB_SCRIPT = """
+local queue_key = ARGV[1]
+local queue_prio_lookup = ARGV[2]
+local job_key = ARGV[3]
+local job_id = ARGV[4]
+local job_priority = tonumber(redis.call("HGET", job_key, "priority")) or 0
+local job_index = 1
+local insert_status = -1
+
+-- Check the priority for the last job in the queue, we might become the new last job
+-- This is generally more efficient than iterating the queue.
+local last_job_id = redis.call("LRANGE", queue_key, -1, -1)[1]
+if last_job_id ~= nil then
+    local last_job_priority = tonumber(redis.call("HGET", queue_prio_lookup, last_job_id)) or 0
+    if last_job_priority >= job_priority then
+        insert_status = redis.call("RPUSH", queue_key, job_id)
+        -- Insert status is the length of the queue
+        job_index = insert_status
+    end
+else
+    -- The queue is empty.
+    insert_status = redis.call("RPUSH", queue_key, job_id)
+end
+
+if insert_status == -1 then
+    -- Our place in the queue is somewhere in the middle, search for it
+    for i, queued_job_id in ipairs(redis.call("LRANGE", queue_key, 0, -1)) do
+        local queued_job_priority = tonumber(redis.call("HGET", queue_prio_lookup, queued_job_id)) or 0
+        if queued_job_priority < job_priority then
+            -- Found the first job with a lower priority, insert before it
+            insert_status = redis.call("LINSERT", queue_key, "BEFORE", queued_job_id, job_id)
+            job_index = i
+            break
+        end
+    end
+end
+
+if insert_status == -1 then
+    -- No higher priority jobs found, insert to the end
+    redis.call("RPUSH", queue_key, job_id)
+end
+
+-- Introduce the newly added job to the priority lookup hash
+redis.call("HSET", queue_prio_lookup, job_id, job_priority)
+
+return job_index
+"""
+
+PRIO_HASH_CLEANER_SCRIPT = """
+local queue_key = ARGV[1]
+local queue_prio_lookup = ARGV[2]
+
+local queue_len = tonumber(redis.call("LLEN", queue_key))
+local hash_len = tonumber(redis.call("HLEN", queue_prio_lookup))
+
+-- Tolerate some excess
+if queue_len + 100 >= hash_len then
+    return -1
+end
+
+local new_hash = {}
+local count = 0
+
+for i, queued_job_id in ipairs(redis.call("LRANGE", queue_key, 0, -1)) do
+    local priority = redis.call("HGET", queue_prio_lookup, queued_job_id)
+    new_hash[queued_job_id] = priority
+    count = i
+end
+redis.call("DEL", queue_prio_lookup)
+
+for queued_job_id, priority in pairs(new_hash) do
+    redis.call("HSET", queue_prio_lookup, queued_job_id, priority)
+end
+
+return hash_len - count
+"""
+
+
+class PriorityQueue(Queue):
+    """Alternate Queue implementation that uses the optional `Job.priority` attribute
+    to sort the queue when adding jobs.
+
+    When using the priority queue, ensure the `PriorityQueue.finish_job()` method is called
+    for each job after it leaves the queue to trim the job priority lookup hash.
+    This can be performed by either the consumer or the job manager, or both.
+
+    Alternately, or in addition, periodically call `PriorityQueue.periodic_clean()` to
+    remove stale keys from the priority lookup hash.
+    """
+
+    def __init__(self, redis: "Redis[bytes]", name: str):
+        super().__init__(redis, name)
+        self.add_job_script = redis.register_script(ADD_JOB_SCRIPT)
+        self.hash_clean_script = redis.register_script(PRIO_HASH_CLEANER_SCRIPT)
+
+    @property
+    def prio_key(self) -> str:
+        return f"{self.redis_key}prio"
+
+    def add_job(self, job: "Job") -> int:
+        script_response = self.add_job_script(
+            keys=[self.redis_key, self.prio_key, job.redis_key],
+            args=[self.redis_key, self.prio_key, job.redis_key, job.id],
+        )
+        return int(script_response) - 1
+
+    def dequeue_job(self, job_id: str) -> bool:
+        """Dequeue a job from any position in the queue, cleaning it from the priority
+        lookup hash.
+        """
+        self.redis.hdel(self.prio_key, job_id)
+        num_removed = self.redis.lrem(self.redis_key, 0, job_id)
+        return num_removed > 0
+
+    def clean_job(self, job: "Job") -> None:
+        """Cleans up job data after the job has exited the queue."""
+        self.redis.hdel(self.prio_key, job.id)
+
+    def periodic_clean(self) -> int:
+        """Perform occasional maintenance on the data structures
+
+        :return: Number of cleaned up values
+        """
+        script_response = self.hash_clean_script(
+            keys=[self.redis_key, self.prio_key],
+            args=[self.redis_key, self.prio_key],
+        )
+        return int(script_response)

--- a/minique/models/queue.py
+++ b/minique/models/queue.py
@@ -58,8 +58,21 @@ class Queue:
 
         index = self.get_queue_index(job)
         if index is None:
-            # RPUSH: Integer reply: the length of the list after the push operation.
-            index = self.redis.rpush(self.redis_key, job.id) - 1
-            return (True, index)
+            index = self.add_job(job)
+            return True, index
 
-        return (False, index)
+        return False, index
+
+    def add_job(self, job: "Job") -> int:
+        """Add a job to the queue in the appropriate position for its priority.
+
+        :param job: The Job object to be added.
+
+        :return: index position of the job in the queue
+        """
+        return self.redis.rpush(self.redis_key, job.id) - 1
+
+    def dequeue_job(self, job_id: str) -> bool:
+        """Dequeue the job with the given job ID"""
+        num_removed = self.redis.lrem(self.redis_key, 0, job_id)
+        return num_removed > 0

--- a/minique/work/worker.py
+++ b/minique/work/worker.py
@@ -50,7 +50,7 @@ class Worker:
 
     def get_next_job(self) -> Optional[Job]:
         rv = self.redis.blpop([q.redis_key for q in self.queues], self.queue_timeout)
-        if rv:  # The rv is a 2-tuple (queue name, value)
+        if rv:  # 2-tuple of queue_key, job_id
             job_id = rv[1].decode()
             return Job(self.redis, job_id)
         return None

--- a/minique_tests/test_minique.py
+++ b/minique_tests/test_minique.py
@@ -129,6 +129,15 @@ def test_stored_jobs(redis: Redis, random_queue_name: str) -> None:
     assert r_job == job
 
 
+def test_dequeue_stored_job(redis: Redis):
+    stored_job = store(
+        redis,
+        "minique_tests.jobs.sum_positive_values",
+    )
+    with pytest.raises(MissingJobData, match="has no queue"):
+        stored_job.dequeue()
+
+
 def test_stored_job_cancel(redis: Redis, random_queue_name: str) -> None:
     job = store(redis, reverse_job_id)
     assert get_job(redis, job.id).status == JobStatus.NONE

--- a/minique_tests/test_priority.py
+++ b/minique_tests/test_priority.py
@@ -1,0 +1,224 @@
+import pytest
+
+from typing import Tuple, Iterable
+
+from redis.client import Redis
+
+from minique.api import enqueue, enqueue_priority, cancel_job
+from minique.models.job import Job
+from minique.models.priority_queue import PriorityQueue
+from minique_tests.worker import TestWorker
+
+
+def assert_queue_items(queue: PriorityQueue, jobs: Iterable[Job]) -> None:
+    queue_items = queue.redis.lrange(queue.redis_key, 0, -1)
+    assert [i.decode() for i in queue_items] == [j.id for j in jobs]
+
+
+def assert_queue_priorities(
+    queue: PriorityQueue, priority_job_map: Iterable[Tuple[Job, int]]
+) -> None:
+    assert queue.redis.hgetall(queue.prio_key) == {
+        job.id.encode(): str(prio).encode() for job, prio in priority_job_map
+    }
+
+
+@pytest.fixture()
+def enqueue_job(redis: Redis, random_queue_name: str):
+    def inner(priority=0, job_id=None):
+        return enqueue_priority(
+            redis,
+            random_queue_name,
+            "minique_tests.jobs.sum_positive_values",
+            priority=priority,
+            job_id=job_id,
+        )
+
+    return inner
+
+
+def test_priority_queueing(redis: Redis, enqueue_job):
+    """Test that jobs can be added to the queue with varying priority"""
+
+    j_p0 = enqueue_job(priority=0)
+    j_pn1 = enqueue_job(priority=-1)
+    j_p2 = enqueue_job(priority=2)
+    j_pn2 = enqueue_job(priority=-2)
+
+    # Add more jobs in existing priorities; these should slot into the right places in the
+    # queue list
+    j_p0_2 = enqueue_job(priority=0)
+    j_pn1_2 = enqueue_job(priority=-1)
+    j_p2_2 = enqueue_job(priority=2)
+    j_pn2_2 = enqueue_job(priority=-2)
+
+    # Add a new job in a new priority between existing ones
+    j_p1 = enqueue_job(priority=1)
+
+    queue = j_p0.get_queue()
+    assert isinstance(queue, PriorityQueue)
+    assert queue.length == 9
+
+    # Exact order of items is by priority block, and FIFO within priority blocks
+    assert_queue_items(
+        queue,
+        [
+            j_p2,
+            j_p2_2,
+            j_p1,
+            j_p0,
+            j_p0_2,
+            j_pn1,
+            j_pn1_2,
+            j_pn2,
+            j_pn2_2,
+        ],
+    )
+    assert_queue_priorities(
+        queue,
+        [
+            (j_p2, 2),
+            (j_p2_2, 2),
+            (j_p1, 1),
+            (j_p0, 0),
+            (j_p0_2, 0),
+            (j_pn1, -1),
+            (j_pn1_2, -1),
+            (j_pn2, -2),
+            (j_pn2_2, -2),
+        ],
+    )
+
+
+def test_larger_queue(redis: Redis, enqueue_job, random_queue_name):
+    job_ids = [
+        enqueue_job(priority=i % 13 - 6, job_id=f"job_{random_queue_name}_1_{i}").id
+        for i in range(1000)
+    ]
+
+    queue = PriorityQueue(redis=redis, name=random_queue_name)
+    assert queue.length == 1000
+
+    # All jobs are queued and order is correct
+    max_priority = 6
+    for job_id in redis.lrange(queue.redis_key, 0, -1):
+        job_id = job_id.decode()
+        job_priority = int(redis.hget(queue.prio_key, job_id))
+        assert job_priority <= max_priority
+        assert job_id in job_ids
+        max_priority = min(job_priority, max_priority)
+
+    # Drain the queue, refill it and rebuild the priority lookup hash
+    redis.delete(queue.redis_key)
+    new_job_ids = {
+        enqueue_job(
+            priority=i % 13 - 6, job_id=f"job_{random_queue_name}_2_{i}"
+        ).id.encode()
+        for i in range(1000)
+    }
+    assert queue.periodic_clean() == 1000
+    # New jobs are the only jobs in the prio hash
+    assert set(redis.hkeys(queue.prio_key)) == new_job_ids
+
+
+@pytest.mark.parametrize("operation", ["cancel_job", "dequeue"])
+def test_dequeue_job(redis: Redis, enqueue_job, operation):
+    j_p0, j_p1, j_p2 = [enqueue_job(priority=n) for n in range(3)]
+    queue = j_p0.get_queue()
+    if operation == "dequeue":
+        # Dequeueing removes the job from the queue and priority hash right away
+        assert j_p0.dequeue()
+    elif operation == "cancel_job":
+        # Cancelling the job also removes it from the queue and priority hash right away
+        assert cancel_job(redis, j_p0.id)
+    assert_queue_priorities(
+        queue,
+        [
+            (j_p1, 1),
+            (j_p2, 2),
+        ],
+    )
+    assert queue.length == 2
+    assert_queue_items(
+        queue,
+        [
+            j_p2,
+            j_p1,
+        ],
+    )
+
+
+def test_ensure_priority_queued(redis: Redis, random_queue_name: str, enqueue_job):
+    j_p0, j_p1, j_p2 = [enqueue_job(priority=n) for n in range(3)]
+    j_p1.dequeue()
+    queue = j_p0.get_queue()
+    was_queued, index = j_p1.ensure_enqueued()
+    assert was_queued
+    assert index == 1
+    # returns to the appropriate place (= used priority queue)
+    assert_queue_items(
+        queue,
+        [
+            j_p2,
+            j_p1,
+            j_p0,
+        ],
+    )
+
+
+def test_worker_consumes_priority_job(
+    redis: Redis, random_queue_name: str, enqueue_job
+):
+    worker = TestWorker.for_queue_names(redis, [random_queue_name])
+
+    j_p0 = enqueue_job(priority=0)
+    j_p1 = enqueue_job(priority=1)
+    j_p1_2 = enqueue_job(priority=1)
+    queue = j_p0.get_queue()
+
+    run_job = worker.tick()
+    assert run_job == j_p1
+
+    # worker doesn't remove the job from the priorities hash
+    assert_queue_priorities(
+        queue,
+        [
+            (j_p0, 0),
+            (j_p1, 1),
+            (j_p1_2, 1),
+        ],
+    )
+
+    # finishing the job removes the job from the priorities hash
+    j_p1.cleanup()
+    assert_queue_priorities(
+        queue,
+        [
+            (j_p0, 0),
+            (j_p1_2, 1),
+        ],
+    )
+
+    # it can be called again
+    j_p1.cleanup()
+
+
+def test_non_priority_mixup(redis: Redis, random_queue_name: str):
+    """Test that priority queueing does not crash even if there are jobs without a
+    priority value in the hash table
+
+    This can happen if the queue clients use priority and non-priority queues interchangeably
+    for some reason. However, we don't guarantee the queue is in a sensible order if so nor
+    attempt to repair it.
+    """
+    for i in range(10):
+        if i % 2:
+            enqueue_priority(
+                redis,
+                random_queue_name,
+                "minique_tests.jobs.sum_positive_values",
+                priority=i - 5,
+            )
+        else:
+            enqueue(redis, random_queue_name, "minique_tests.jobs.sum_positive_values")
+    assert PriorityQueue(redis, random_queue_name).length == 10


### PR DESCRIPTION
Use the power of Redis Lua scripting to implement priority queueing by sorting the queue list for each job priority.

While this approach has its limits if the queue is very long, as each insert iterates the entire queue at most twice, it is fully compatible with existing queue consumers who don't need to know about job priorities.