### PR TITLE
Use orjson when possible; drop JSONEncoder's stdlib specific JSON customizations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,9 @@ jobs:
       - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           python-version: '3.13'
-      - run: uv run --all-extras mypy --strict --install-types --non-interactive --show-error-codes minique
+          activate-environment: 'true'
+      # `mypy` requires `pip` to install types...
+      - run: uv run --with=pip --all-extras mypy --strict --install-types --non-interactive --show-error-codes minique
 
   Build:
     runs-on: ubuntu-24.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
           - { python-version: '3.12', install-extra: '[redis]' }
           - { python-version: '3.13', install-extra: '[redis]' }
           - { python-version: '3.13', install-extra: '[redis,sentry]'}
+          - { python-version: '3.13', install-extra: '[redis,sentry,orjson]'}
           # With the Valkey server
           - { python-version: '3.13', install-extra: '[redis]', redis-image: 'valkey/valkey:8'}
           # With the Valkey client and Valkey server

--- a/README.md
+++ b/README.md
@@ -98,7 +98,14 @@ job.cleanup()
 job = get_job(redis, job_id)
 ```
 
-## Sentry Support
+## Library support
+
+### orjson
+
+If [`orjson`](https://github.com/ijl/orjson) is installed,
+it will automatically be used for faster JSON serialization and deserialization of job arguments and results.
+
+### Sentry
 
 Minique automatically integrates with the [Sentry](https://sentry.io/welcome/)
 exception tracking service.

--- a/minique/encoding.py
+++ b/minique/encoding.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-import json
 from collections.abc import Callable
 from typing import Any
+
+from minique.json import from_json, to_json_bytes
 
 registry = {}
 default_encoding_name: str | None = None
@@ -41,24 +42,17 @@ class JSONEncoding(BaseEncoding):
     Default (JSON) encoding for kwargs and results.
     """
 
-    # These can be effortlessly overridden in subclasses
-    dump_kwargs: dict[str, Any] = {
-        "ensure_ascii": False,
-        "separators": (",", ":"),
-    }
-    load_kwargs: dict[str, Any] = {}
-    failsafe_default = str
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        super().__init_subclass__(**kwargs)
+        for attr in ("dump_kwargs", "load_kwargs", "failsafe_default"):
+            if attr in cls.__dict__:
+                raise TypeError(
+                    f"{cls.__name__} sets removed attribute {attr!r}; "
+                    f"override encode()/decode() directly instead",
+                )
 
     def encode(self, value: Any, failsafe: bool = False) -> str | bytes:
-        kwargs = self.dump_kwargs.copy()
-        if failsafe:
-            kwargs["default"] = self.failsafe_default
-        return json.dumps(
-            value,
-            **kwargs,
-        )
+        return to_json_bytes(value, default=str if failsafe else None)
 
     def decode(self, value: str | bytes) -> Any:
-        if isinstance(value, bytes):
-            value = value.decode()
-        return json.loads(value, **self.load_kwargs)
+        return from_json(value)

--- a/minique/json.py
+++ b/minique/json.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from typing import Any
+
+try:
+    import orjson
+
+    def from_json(data: str | bytes) -> Any:
+        return orjson.loads(data)
+
+    def to_json_bytes(value: Any, *, default: Any = None) -> bytes:
+        return orjson.dumps(value, default=default, option=orjson.OPT_NON_STR_KEYS)
+
+    def to_json_str(value: Any, *, default: Any = None) -> str:
+        return to_json_bytes(value, default=default).decode()
+
+except ImportError:
+    import json
+
+    def from_json(data: str | bytes) -> Any:
+        return json.loads(data)
+
+    def to_json_bytes(value: Any, *, default: Any = None) -> bytes:
+        return json.dumps(
+            value,
+            default=default,
+            ensure_ascii=False,
+            separators=(",", ":"),
+        ).encode()
+
+    def to_json_str(value: Any, *, default: Any = None) -> str:
+        return json.dumps(
+            value,
+            default=default,
+            ensure_ascii=False,
+            separators=(",", ":"),
+        )

--- a/minique/models/job.py
+++ b/minique/models/job.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 import time
 from collections.abc import Callable
 from functools import cached_property
@@ -16,6 +15,7 @@ from minique.excs import (
     MissingJobData,
     NoSuchJob,
 )
+from minique.json import from_json
 
 if TYPE_CHECKING:
     from minique.models.priority_queue import PriorityQueue
@@ -82,7 +82,7 @@ class Job:
         # Acquisition info is always stored as JSON, not with the `encoding`
         acquisition_json = self.redis.hget(self.redis_key, "acquired")
         if acquisition_json:
-            return json.loads(acquisition_json.decode())  # type: ignore[no-any-return]
+            return from_json(acquisition_json)  # type: ignore[no-any-return]
         return None
 
     @property

--- a/minique/work/job_runner.py
+++ b/minique/work/job_runner.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import fnmatch
-import json
 import logging
 import random
 import sys
@@ -12,6 +11,7 @@ from typing import TYPE_CHECKING, Any
 
 from minique.enums import JobStatus
 from minique.excs import AlreadyAcquired, AlreadyResulted, InvalidJob
+from minique.json import to_json_str
 from minique.models.job import Job
 from minique.utils import _set_current_job, import_by_string
 
@@ -32,7 +32,7 @@ class JobRunner:
         job.ensure_exists()
 
     def acquire(self) -> None:
-        new_acquisition_info = json.dumps(self.get_acquisition_info(), default=str)
+        new_acquisition_info = to_json_str(self.get_acquisition_info(), default=str)
         if not self.redis.hsetnx(self.job.redis_key, "acquired", new_acquisition_info):
             raise AlreadyAcquired(
                 f"job {self.job.id} already acquired: {self.job.acquisition_info}"

--- a/minique_tests/jobs.py
+++ b/minique_tests/jobs.py
@@ -1,5 +1,5 @@
-import datetime
 import queue
+import threading
 import time
 
 from minique.utils import get_current_job
@@ -19,8 +19,8 @@ def wrap_kwargs(**kwargs):
     return dict(kwargs.copy())
 
 
-def job_with_unjsonable_retval() -> datetime.datetime:
-    return datetime.datetime.now()
+def job_with_unjsonable_retval() -> threading.Lock:
+    return threading.Lock()
 
 
 def reverse_job_id() -> str:

--- a/minique_tests/test_customization.py
+++ b/minique_tests/test_customization.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
+import json
 from typing import TYPE_CHECKING
 
 import pytest
 
 from minique.api import enqueue
-from minique.encoding import JSONEncoding, register_encoding
+from minique.encoding import BaseEncoding, register_encoding
 from minique.testing import run_synchronously
 from minique.work.job_runner import JobRunner
 from minique_tests.worker import TestWorker
@@ -27,9 +28,19 @@ def special_load(o):
 
 
 @register_encoding("special_json")
-class SpecialJSONEncoding(JSONEncoding):
-    load_kwargs = dict(JSONEncoding.load_kwargs, object_hook=special_load)
-    dump_kwargs = dict(JSONEncoding.dump_kwargs, default=special_dump)
+class SpecialJSONEncoding(BaseEncoding):
+    def encode(self, value, failsafe=False):
+        return json.dumps(
+            value,
+            default=special_dump,
+            ensure_ascii=False,
+            separators=(",     ", "     :"),  # why would you?
+        )
+
+    def decode(self, value):
+        if isinstance(value, bytes):
+            value = value.decode()
+        return json.loads(value, object_hook=special_load)
 
 
 class HonkJobRunner(JobRunner):

--- a/minique_tests/test_errors.py
+++ b/minique_tests/test_errors.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import time
-import uuid
 from typing import TYPE_CHECKING
 
 import pytest
@@ -41,7 +40,7 @@ def check_sentry_event_calls(sentry_event_calls, num_expected: int):
 
 def test_unjsonable_arg(redis: RedisClient, random_queue_name: str):
     kwargs = {
-        "phooey": uuid.uuid4(),
+        "phooey": object(),
     }
     with pytest.raises(TypeError):
         enqueue(redis, random_queue_name, job_with_unjsonable_retval, kwargs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,9 @@ valkey = [
 sentry = [
     "sentry-sdk~=2.36",
 ]
+orjson = [
+    "orjson",
+]
 
 [project.scripts]
 minique = "minique.cli:main"
@@ -37,6 +40,10 @@ path = "minique/__init__.py"
 include = [
     "/minique",
 ]
+
+[[tool.mypy.overrides]]
+module = "orjson.*"
+ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = "sentry_sdk.*"


### PR DESCRIPTION
For performance, and simplicity!

For backward compatibility, subclassed JSONEncoders will scream loudly if they had been customized in a way that will henceforth be unsupported.