### PR TITLE
Add best-effort affinity-aware job queuing

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,42 @@ job.cleanup()
 job = get_job(redis, job_id)
 ```
 
+### Affinity
+
+Jobs can carry one or more opaque **affinity specifiers** — typically identifiers for
+something expensive to fetch, for instance.
+A worker that recently ran a job with a given specifier becomes "warm" for it and *prefers*
+to pick up further jobs with the same specifier.
+
+This is purely an optimization and never a constraint. Workers may always end up pulling jobs
+from the base queue, and jobs may be picked up by any worker regardless of affinity.
+
+```python
+from minique.api import enqueue
+
+# Two jobs that both need the same large dataset will prefer the same worker:
+job_a = enqueue(redis, 'training', 'my_jobs.train', kwargs={'fold': 0}, affinity=['dataset-42'])
+job_b = enqueue(redis, 'training', 'my_jobs.train', kwargs={'fold': 1}, affinity=['dataset-42'])
+```
+
+`enqueue_priority` accepts `affinity` too; each affinity sub-queue is itself a priority queue,
+so ordering within a specifier still respects `priority`.
+
+> **Affinity outranks priority on a warm worker.** Because a warm worker checks its affinity
+> sub-queues before the base queue, it can pick up a *lower*-priority affine job ahead of a
+> *higher*-priority job waiting in the base priority queue.
+
+#### Cleaning up sub-queue residue
+
+Affinity sub-queues self-heal while jobs for a specifier keep flowing. Once a specifier goes
+quiet, a little residue can linger (phantom ids for expired jobs, and orphaned `…prio` hashes
+for priority queues). Trim it on demand with
+
+`minique.api.clean_affinity_sub_queues(redis, base_queue_name, priority=...)`.
+
+The call is idempotent, best-effort, and safe to run concurrently from many workers, so the
+simplest approach is to fire it occasionally with e.g. `random.random() < 0.01`.
+
 ## Library support
 
 ### orjson

--- a/minique/api.py
+++ b/minique/api.py
@@ -7,10 +7,20 @@ from typing import TYPE_CHECKING, Any
 import minique.encoding as encoding
 from minique.enums import JobStatus
 from minique.excs import DuplicateJob
+from minique.json import to_json_bytes
 from minique.models.job import Job
 from minique.models.priority_queue import PriorityQueue
 from minique.models.queue import Queue
 from minique.utils import get_random_pronounceable_string
+from minique.utils.affinity import (
+    get_affinity_queue_name,
+    get_affinity_sub_queue_names,
+    normalize_affinity,
+)
+from minique.utils.cleaning import (
+    remove_orphaned_prio_hashes,
+    trim_phantom_ids,
+)
 
 if TYPE_CHECKING:
     from minique.types import RedisClient
@@ -25,6 +35,7 @@ def enqueue(
     job_ttl: int = 0,
     result_ttl: int = 86400 * 7,
     encoding_name: str | None = None,
+    affinity: list[str] | None = None,
 ) -> Job:
     """
     Queue up callable as a job.
@@ -37,11 +48,15 @@ def enqueue(
     :param job_ttl: Time-to-live for the job in seconds; defaults to never expire.
     :param result_ttl: Time-to-live for the result in seconds; defaults to 7 days.
     :param encoding_name: Name of the encoding to use for the job payload; defaults to JSON.
+    :param affinity: Optional best-effort affinity specifiers (e.g. dataset IDs or
+                     image digests). Workers that recently ran jobs with the same
+                     specifier will prefer to pick this job up, to exploit warm caches.
+                     This is purely an optimization; the job is always reachable on the
+                     base queue regardless.
     :raises minique.excs.DuplicateJob: If a job with the same ID already exists.
     :raises minique.excs.NoSuchJob: If the job does not exist right after creation.
     """
-    queue = Queue(redis, queue_name)
-    job = _define_and_store_job(
+    return _define_and_store_job(
         redis=redis,
         callable=callable,
         kwargs=kwargs,
@@ -49,9 +64,9 @@ def enqueue(
         job_ttl=job_ttl,
         result_ttl=result_ttl,
         encoding_name=encoding_name,
-        queue=queue,
+        queue=Queue(redis, queue_name),
+        affinity=affinity,
     )
-    return job
 
 
 def enqueue_priority(
@@ -64,6 +79,7 @@ def enqueue_priority(
     result_ttl: int = 86400 * 7,
     encoding_name: str | None = None,
     priority: int = 0,
+    affinity: list[str] | None = None,
 ) -> Job:
     """
     Queue up callable as a job, placing the job at the last place for its priority.
@@ -77,11 +93,17 @@ def enqueue_priority(
     :param result_ttl: Time-to-live for the result in seconds; defaults to 7 days.
     :param encoding_name: Name of the encoding to use for the job payload; defaults to JSON.
     :param priority: Priority number of this job, defaults to zero.
+    :param affinity: Optional best-effort affinity specifiers; see `enqueue`. Each
+                     affinity sub-queue is itself a priority queue, so within-affinity
+                     ordering still respects `priority`. Note that affinity outranks
+                     priority on a warm worker: it checks its affinity sub-queues before
+                     the base queue, so a lower-priority affine job can be picked up ahead
+                     of a higher-priority job in the base queue. Don't attach affinity to
+                     jobs that require strict global priority ordering.
     :raises minique.excs.DuplicateJob: If a job with the same ID already exists.
     :raises minique.excs.NoSuchJob: If the job does not exist right after creation.
     """
-    queue = PriorityQueue(redis, queue_name)
-    job = _define_and_store_job(
+    return _define_and_store_job(
         redis=redis,
         callable=callable,
         kwargs=kwargs,
@@ -89,10 +111,10 @@ def enqueue_priority(
         job_ttl=job_ttl,
         result_ttl=result_ttl,
         encoding_name=encoding_name,
-        queue=queue,
+        queue=PriorityQueue(redis, queue_name),
         priority=priority,
+        affinity=affinity,
     )
-    return job
 
 
 def store(
@@ -171,7 +193,7 @@ def cancel_job(
     return False
 
 
-def _define_and_store_job(
+def _define_and_store_job(  # noqa: C901
     *,
     redis: RedisClient,
     callable: Callable[..., Any] | str,
@@ -182,6 +204,7 @@ def _define_and_store_job(
     encoding_name: str | None = None,
     queue: Queue | None = None,
     priority: int | None = None,
+    affinity: list[str] | None = None,
 ) -> Job:
     if not encoding_name:
         encoding_name = encoding.default_encoding_name
@@ -211,14 +234,43 @@ def _define_and_store_job(
     if priority is not None:
         payload["priority"] = priority
 
+    if affinity := normalize_affinity(affinity):
+        payload["affinity"] = to_json_bytes(affinity)
+
     with redis.pipeline() as p:
         p.hset(job.redis_key, mapping=payload)  # type: ignore[arg-type]
         if payload["job_ttl"] > 0:
             p.expire(job.redis_key, payload["job_ttl"])
+
+        if queue:
+            if affinity:
+                queue.add_job_to_pipeline(p, job)
+                for specifier in affinity:
+                    sub_queue_name = get_affinity_queue_name(queue.name, specifier)
+                    sub_queue = type(queue)(redis, sub_queue_name)
+                    sub_queue.add_job_to_pipeline(p, job)
+            else:
+                queue.add_job_to_pipeline(p, job)
+
         p.execute()
 
-    if queue:
-        queue.add_job(job)
-
-    job.ensure_exists()
     return job
+
+
+def clean_affinity_sub_queues(
+    redis: RedisClient,
+    base: str,
+    *,
+    priority: bool = False,
+) -> int:
+    """Trim residue from `base`'s affinity sub-queues; returns the number of items removed.
+
+    This doesn't need to be called often.
+    """
+    removed = 0
+    for name in get_affinity_sub_queue_names(redis, base):
+        sub_queue = PriorityQueue(redis, name) if priority else Queue(redis, name)
+        removed += trim_phantom_ids(redis, sub_queue.redis_key, priority=priority)
+    if priority:
+        removed += remove_orphaned_prio_hashes(redis, base)
+    return removed

--- a/minique/consts.py
+++ b/minique/consts.py
@@ -1,3 +1,11 @@
 QUEUE_KEY_PREFIX = "mqq:"
 JOB_KEY_PREFIX = "mqj:"
 RESULT_KEY_PREFIX = "mqr:"
+
+# Suffix of a PriorityQueue's priority lookup hash key (see PriorityQueue.prio_key).
+PRIO_KEY_SUFFIX = "prio"
+
+# Infix separating a base queue name from a hashed affinity specifier in an affinity sub-queue name.
+# No special (e.g. invisible/control) characters are used, so as to keep things introspectable
+# using ASCII only.
+AFFINITY_QUEUE_INFIX = "+AFF+"

--- a/minique/models/job.py
+++ b/minique/models/job.py
@@ -28,6 +28,10 @@ class Job:
     replacement_callable: Callable[..., Any] | None = None
     replacement_kwargs: dict[str, Any] | None = None
 
+    # Set by Worker.get_next_job() if affinity is in use.
+    source_queue_key: str | None = None
+    affinity_specifier: str | None = None
+
     def __init__(self, redis: RedisClient, id: str) -> None:
         self.redis = redis
         self.id = str(id)
@@ -56,9 +60,18 @@ class Job:
 
     def dequeue(self) -> bool:
         """
-        Remove the job from the queue without changing its status.
+        Remove the job from its queue(s) without changing its status.
+
+        Removes the job from its base queue and from every affinity sub-queue it was
+        dual-written to, so a dequeued (or cancelled) affine job can't still be popped
+        from a warm worker's sub-queue.
+
+        :return: True if the job was removed from at least one queue.
         """
-        return self.get_queue().dequeue_job(self.id)
+        queue = self.get_queue()
+        if affinity := self.affinity:
+            return queue.dequeue_affine_job(self.id, affinity)
+        return queue.dequeue_job(self.id)
 
     def cleanup(self) -> bool:
         if self.has_priority:
@@ -84,6 +97,13 @@ class Job:
         if acquisition_json:
             return from_json(acquisition_json)  # type: ignore[no-any-return]
         return None
+
+    @cached_property  # Affinities are considered immutable.
+    def affinity(self) -> list[str]:
+        return _decode_affinity(self.redis.hget(self.redis_key, "affinity"))
+
+    def _cache_affinity(self, affinity_json: bytes | str | None) -> None:
+        self.__dict__["affinity"] = _decode_affinity(affinity_json)
 
     @property
     def has_finished(self) -> int:
@@ -240,3 +260,9 @@ class Job:
 
     def __eq__(self, other: Any) -> bool:
         return isinstance(other, Job) and (self.id == other.id)
+
+
+def _decode_affinity(affinity_json: bytes | str | None) -> list[str]:
+    if affinity_json:
+        return from_json(affinity_json)  # type: ignore[no-any-return]
+    return []

--- a/minique/models/priority_queue.py
+++ b/minique/models/priority_queue.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
+from collections.abc import Iterable
 from typing import TYPE_CHECKING
 
+from minique.consts import PRIO_KEY_SUFFIX
 from minique.models.queue import Queue
+from minique.utils.affinity import get_affinity_sub_queue_key
 
 if TYPE_CHECKING:
     from minique.models.job import Job
-    from minique.types import RedisClient
-
+    from minique.types import RedisClient, RedisPipeline
 
 ADD_JOB_SCRIPT = """
 local queue_key = ARGV[1]
@@ -97,6 +99,13 @@ class PriorityQueue(Queue):
 
     Alternately, or in addition, periodically call `PriorityQueue.periodic_clean()` to
     remove stale keys from the priority lookup hash.
+
+    Note on affinity: when jobs are enqueued with `affinity`, each affinity sub-queue is
+    its own `PriorityQueue` with its own `…prio` lookup hash. `clean_job`/`periodic_clean`
+    only touch the queue they are called on, so sub-queue hashes are not cleaned by
+    operating on the base queue. Use `minique.api.clean_affinity_sub_queues(...,
+    priority=True)` to trim drained sub-queues (and their hashes) on demand; residue is
+    otherwise self-healing while jobs for a specifier keep flowing.
     """
 
     def __init__(self, redis: RedisClient, name: str):
@@ -106,7 +115,11 @@ class PriorityQueue(Queue):
 
     @property
     def prio_key(self) -> str:
-        return f"{self.redis_key}prio"
+        return f"{self.redis_key}{PRIO_KEY_SUFFIX}"
+
+    def _get_clear_keys(self) -> Iterable[str | bytes]:
+        yield from super()._get_clear_keys()
+        yield self.prio_key
 
     def add_job(self, job: Job) -> int:
         script_response = self.add_job_script(
@@ -115,6 +128,13 @@ class PriorityQueue(Queue):
         )
         return int(script_response) - 1
 
+    def add_job_to_pipeline(self, pipeline: RedisPipeline, job: Job) -> None:
+        self.add_job_script(
+            keys=[self.redis_key, self.prio_key, job.redis_key],
+            args=[self.redis_key, self.prio_key, job.redis_key, job.id],
+            client=pipeline,
+        )
+
     def dequeue_job(self, job_id: str) -> bool:
         """Dequeue a job from any position in the queue, cleaning it from the priority
         lookup hash.
@@ -122,6 +142,23 @@ class PriorityQueue(Queue):
         self.redis.hdel(self.prio_key, job_id)
         num_removed = self.redis.lrem(self.redis_key, 0, job_id)
         return num_removed > 0
+
+    def dequeue_affine_job(self, job_id: str, affinity_keys: list[str]) -> bool:
+        # Gather main + prio queue + affine subqueues + affine prio subqueues.
+        list_keys = [self.redis_key]
+        prio_keys = [f"{self.redis_key}{PRIO_KEY_SUFFIX}"]
+        for specifier in affinity_keys:
+            sub_key = get_affinity_sub_queue_key(self.name, specifier)
+            list_keys.append(sub_key)
+            prio_keys.append(f"{sub_key}{PRIO_KEY_SUFFIX}")
+        with self.redis.pipeline(transaction=False) as p:
+            for prio_key in prio_keys:
+                p.hdel(prio_key, job_id)
+            for list_key in list_keys:
+                p.lrem(list_key, 0, job_id)
+            results = p.execute()
+        # The LREM reply counts come after the HDEL replies, in list_keys order.
+        return any(count for count in results[len(prio_keys) :])
 
     def clean_job(self, job: Job) -> None:
         """Cleans up job data after the job has exited the queue."""

--- a/minique/models/queue.py
+++ b/minique/models/queue.py
@@ -1,21 +1,25 @@
 from __future__ import annotations
 
+from collections.abc import Iterable
 from functools import cached_property
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from minique.consts import QUEUE_KEY_PREFIX
 from minique.excs import NoSuchJob
+from minique.utils.affinity import affinity_queue_name_glob, get_affinity_sub_queue_key
 from minique.utils.redis_list import read_list
 
 if TYPE_CHECKING:
     from minique.models.job import Job
-    from minique.types import RedisClient
+    from minique.types import RedisClient, RedisPipeline
 
 
 class Queue:
     def __init__(self, redis: RedisClient, name: str) -> None:
         self.redis = redis
         self.name = str(name)
+        if "*" in self.name:
+            raise ValueError("Queue name may not contain '*'")
 
     @cached_property
     def redis_key(self) -> str:
@@ -25,11 +29,22 @@ class Queue:
     def length(self) -> int:
         return self.redis.llen(self.redis_key)
 
-    def clear(self) -> Any:
+    def clear(self) -> int:
         """
         Entirely clear this queue. Do not call this unless you're willing to risk orphaned jobs.
+
+        This also deletes any affinity sub-queues dual-written for this queue,
+        and priority lookup hashes.
+
+        :return: The number of Redis keys deleted.
         """
-        return self.redis.delete(self.redis_key)
+        return self.redis.delete(*(self._get_clear_keys()))
+
+    def _get_clear_keys(self) -> Iterable[str | bytes]:
+        yield self.redis_key
+        yield from self.redis.scan_iter(
+            match=f"{QUEUE_KEY_PREFIX}{affinity_queue_name_glob(self.name)}",
+        )
 
     def get_queue_index(self, job: Job) -> int | None:
         # TODO: use `LPOS` (https://redis.io/commands/lpos/) when available for this
@@ -73,7 +88,24 @@ class Queue:
         """
         return self.redis.rpush(self.redis_key, job.id) - 1
 
+    def add_job_to_pipeline(self, pipeline: RedisPipeline, job: Job) -> None:
+        """Queue this job's enqueue command onto `pipeline` (no index returned)."""
+        pipeline.rpush(self.redis_key, job.id)
+
     def dequeue_job(self, job_id: str) -> bool:
         """Dequeue the job with the given job ID"""
         num_removed = self.redis.lrem(self.redis_key, 0, job_id)
         return num_removed > 0
+
+    def dequeue_affine_job(self, job_id: str, affinity_keys: list[str]) -> bool:
+        with self.redis.pipeline(transaction=False) as p:
+            # Dequeue from main queue, and any affine subqueues.
+            for list_key in [
+                self.redis_key,
+                *(
+                    get_affinity_sub_queue_key(self.name, specifier)
+                    for specifier in affinity_keys
+                ),
+            ]:
+                p.lrem(list_key, 0, job_id)
+            return any(p.execute())

--- a/minique/types.py
+++ b/minique/types.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
     import redis
 
     RedisClient: TypeAlias = redis.Redis[bytes]
+    RedisPipeline: TypeAlias = redis.client.Pipeline[bytes]
 
     # TODO: the types for `valkey` are suboptimal (since they are so in the original
     #       pre-fork `redis` package), so adding `| valkey.Valkey` to the above type alias

--- a/minique/utils/affinity.py
+++ b/minique/utils/affinity.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Iterable
+from functools import lru_cache
+from typing import TYPE_CHECKING, Any
+
+from minique.consts import AFFINITY_QUEUE_INFIX, PRIO_KEY_SUFFIX, QUEUE_KEY_PREFIX
+from minique.utils.cleaning import _scan_decoded
+
+if TYPE_CHECKING:
+    from minique.types import RedisClient
+
+
+def normalize_affinity(affinity: list[Any] | None) -> list[str]:
+    """De-duplicate (order-preserving) and validate affinity specifiers."""
+    if not affinity:
+        return []
+    if any(not isinstance(s, str) for s in affinity):
+        raise TypeError("affinity specifiers must be strings")
+    specifiers = [s for s in affinity if s]
+    return list(dict.fromkeys(specifiers))
+
+
+def get_affinity_sub_queue_names(redis: RedisClient, base: str) -> Iterable[str]:
+    """Return the (base-relative) names of all existing affinity sub-queues for `base`."""
+    match = f"{QUEUE_KEY_PREFIX}{affinity_queue_name_glob(base)}"
+    prefix_len = len(QUEUE_KEY_PREFIX)
+    for key in _scan_decoded(redis, match):
+        # The same prefix also matches each PriorityQueue's `…prio` lookup hash; skip it.
+        if key.endswith(PRIO_KEY_SUFFIX):
+            continue
+        yield key[prefix_len:]
+
+
+@lru_cache
+def get_affinity_queue_name(base: str, specifier: str) -> str:
+    """Derive the name of `base` queue's affinity sub-queue for `specifier`."""
+    # Truncated SHA-1 hash to keep collisions at bay, instead of having to escape specifiers.
+    digest = hashlib.sha1(specifier.encode("utf-8")).hexdigest()[:16]
+    return f"{base}{AFFINITY_QUEUE_INFIX}{digest}"
+
+
+@lru_cache
+def get_affinity_sub_queue_key(base: str, specifier: str) -> str:
+    """Full Redis key (prefix included) of the affinity sub-queue for `specifier`."""
+    return f"{QUEUE_KEY_PREFIX}{get_affinity_queue_name(base, specifier)}"
+
+
+@lru_cache
+def glob_escape(value: str) -> str:
+    """Escape Redis glob-style `MATCH` metacharacters so `value` is matched literally."""
+    escaped = []
+    for char in value:
+        if char in "\\*?[]":
+            escaped.append("\\")
+        escaped.append(char)
+    return "".join(escaped)
+
+
+def affinity_queue_name_glob(base: str) -> str:
+    """`MATCH` glob (base-relative) for every affinity sub-queue name of `base`."""
+    return f"{glob_escape(base)}{AFFINITY_QUEUE_INFIX}*"

--- a/minique/utils/cleaning.py
+++ b/minique/utils/cleaning.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import TYPE_CHECKING
+
+from minique.consts import (
+    JOB_KEY_PREFIX,
+    PRIO_KEY_SUFFIX,
+    QUEUE_KEY_PREFIX,
+)
+
+if TYPE_CHECKING:
+    from minique.types import RedisClient
+
+
+def _scan_decoded(redis: RedisClient, match: str) -> Iterator[str]:
+    """Yield `SCAN` matches as `str`, decoding the bytes a `redis[bytes]` client returns."""
+    for raw_key in redis.scan_iter(match=match):
+        yield raw_key.decode() if isinstance(raw_key, bytes) else raw_key
+
+
+def trim_phantom_ids(redis: RedisClient, list_key: str, *, priority: bool) -> int:
+    """Remove ids whose job hash no longer exists from one affinity sub-queue list."""
+    ids = [raw_id.decode() for raw_id in redis.lrange(list_key, 0, -1)]
+    if not ids:
+        return 0
+    # Check existence of all ids in one round-trip, then trim the phantoms.
+    with redis.pipeline(transaction=False) as p:
+        for job_id in ids:
+            p.exists(f"{JOB_KEY_PREFIX}{job_id}")
+        exists_flags = p.execute()
+    phantoms = [
+        jid for jid, exists in zip(ids, exists_flags, strict=True) if not exists
+    ]
+    if not phantoms:
+        return 0
+    prio_key = f"{list_key}{PRIO_KEY_SUFFIX}"
+    with redis.pipeline(transaction=False) as p:
+        for job_id in phantoms:
+            if priority:  # mirror PriorityQueue.dequeue_job: HDEL then LREM
+                p.hdel(prio_key, job_id)
+            p.lrem(list_key, 0, job_id)
+        p.execute()
+    return len(phantoms)
+
+
+ORPHANED_PRIO_CLEANER_SCRIPT = """
+local deleted = 0
+for i = 1, #KEYS do
+    if redis.call("LLEN", ARGV[i]) == 0 then
+        deleted = deleted + redis.call("DEL", KEYS[i])
+    end
+end
+return deleted
+"""
+
+
+def remove_orphaned_prio_hashes(redis: RedisClient, base: str) -> int:
+    """Delete `…prio` hashes left orphaned after their affinity sub-queue list drained."""
+    from minique.utils.affinity import affinity_queue_name_glob
+
+    # Per key pair, delete the `…prio` hash (KEYS[i]) only if its sub-queue list (ARGV[i])
+    # is empty, atomically. A plain LLEN-then-DEL split across round-trips would race a
+    # producer's ADD_JOB_SCRIPT (which RPUSHes the list and HSETs the hash atomically): the
+    # producer could re-fill both between our check and our delete, and we'd then wipe a live
+    # prio hash, silently corrupting within-specifier priority ordering.
+
+    match = f"{QUEUE_KEY_PREFIX}{affinity_queue_name_glob(base)}{PRIO_KEY_SUFFIX}"
+    prio_keys = list(_scan_decoded(redis, match))
+    if not prio_keys:
+        return 0
+    list_keys = [pk[: -len(PRIO_KEY_SUFFIX)] for pk in prio_keys]
+    delete_script = redis.register_script(ORPHANED_PRIO_CLEANER_SCRIPT)
+    deleted = delete_script(prio_keys, list_keys)
+    return int(deleted)

--- a/minique/work/job_runner.py
+++ b/minique/work/job_runner.py
@@ -39,6 +39,15 @@ class JobRunner:
             )
         self.redis.hset(self.job.redis_key, "status", JobStatus.ACQUIRED.value)
         self.redis.persist(self.job.redis_key)
+        try:
+            if self.job.affinity:  # Best-effort dequeue this job from sub-queues.
+                self.job.dequeue()
+        except Exception:
+            self.log.warning(
+                "failed acquisition dequeue for job %s",
+                self.job.id,
+                exc_info=True,
+            )
 
     def get_acquisition_info(self) -> dict[str, Any]:
         # Override me in a subclass if you like!
@@ -93,6 +102,11 @@ class JobRunner:
         try:
             encoding = self.job.get_encoding()
             self.acquire()
+        except AlreadyAcquired:
+            # Expected with affinity dual-write: another worker won the same-instant pop
+            # race for one of this job's copies. Let the caller (Worker.tick) treat it as
+            # a quiet phantom; it is not an error worth reporting.
+            raise
         except Exception as exc:
             self.process_exception(sys.exc_info())
             raise exc  # could have had an exception in process_exception  # noqa: TRY201

--- a/minique/work/worker.py
+++ b/minique/work/worker.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import time
 from collections.abc import Iterable
 from os import getpid
 from platform import node
@@ -8,8 +9,10 @@ from typing import TYPE_CHECKING, Any
 
 from minique.compat import sentry_sdk
 from minique.enums import JobStatus
+from minique.excs import AlreadyAcquired, NoSuchJob
 from minique.models.job import Job
 from minique.models.queue import Queue
+from minique.utils.affinity import get_affinity_sub_queue_key
 from minique.work.job_runner import JobRunner
 
 if TYPE_CHECKING:
@@ -23,6 +26,10 @@ class Worker:
     # This property may be ignored by subclasses, but it's here for convenience's sake.
     allowed_callable_patterns: Iterable[str] = frozenset()
 
+    # Best-effort affinity tuning (subclass-overridable):
+    affinity_window = 1800  # seconds a specifier stays "warm" after last use
+    affinity_max_specifiers = 50  # cap on simultaneously-warm specifiers
+
     def __init__(
         self,
         redis: RedisClient,
@@ -33,6 +40,7 @@ class Worker:
         self.queues = list(queues)
         self.log = logging.getLogger(f"{__name__}.{self.id.replace('.', '_')}")
         assert all(isinstance(q, Queue) for q in queues)
+        self.warm_specifiers: dict[str, float] = {}
 
     @classmethod
     def for_queue_names(
@@ -51,22 +59,95 @@ class Worker:
         node_base = node().split(".")[0]
         return f"w-{node_base}-{getpid()}"
 
+    def get_current_warm_specifiers(self) -> list[str]:
+        """Return currently-warm specifiers, most-recently-used first.
+
+        As a side-effect, prunes old entries.
+        """
+        cutoff = time.time() - self.affinity_window
+        self.warm_specifiers = {
+            s: t for s, t in self.warm_specifiers.items() if t >= cutoff
+        }
+        kept = sorted(
+            self.warm_specifiers,
+            key=self.warm_specifiers.__getitem__,
+            reverse=True,
+        )[: self.affinity_max_specifiers]
+        self.warm_specifiers = {s: self.warm_specifiers[s] for s in kept}
+        return kept
+
+    def get_blpop_keys(self) -> dict[str, str | None]:
+        """Build the BLPOP key set as an ordered `redis_key -> affinity specifier` map,
+        grouped per queue: for each queue (in its existing priority order) its warm
+        affinity sub-queues, then its base queue.
+
+        The mapping value is the specifier whose sub-queue the key is, or None for a base
+        queue, so a popped key can be classified without reversing its (one-way hashed)
+        name. The dict is insertion-ordered, which BLPOP reads as priority order.
+        """
+        # Grouping per queue preserves queue-order-as-priority — all of a higher-priority
+        # queue's work (affinity sub-queues included) is preferred over a lower-priority
+        # queue's. Affinity only re-orders *within* a queue. With an empty warm set this is
+        # byte-for-byte the plain base-queue key list, so a cold worker is unchanged.
+        keys: dict[str, str | None] = {}  # de-dupes, order-preserving
+        warm = self.get_current_warm_specifiers()  # Has side-effects, so run once only
+        for q in self.queues:
+            for s in warm:
+                keys.setdefault(get_affinity_sub_queue_key(q.name, s), s)
+            keys.setdefault(q.redis_key, None)
+        return keys
+
     def get_next_job(self) -> Job | None:
-        rv = self.redis.blpop([q.redis_key for q in self.queues], self.queue_timeout)
-        if rv:  # 2-tuple of queue_key, job_id
-            job_id = rv[1].decode()
-            return Job(self.redis, job_id)
-        return None
+        key_map = self.get_blpop_keys()
+        rv = self.redis.blpop(list(key_map), self.queue_timeout)
+        if not rv:  # Timed out with nothing to pop. Carry on.
+            return None
+        raw_source_key, raw_job_id = rv
+        source_key = raw_source_key.decode()
+        job = Job(self.redis, raw_job_id.decode())
+        job.source_queue_key = source_key
+        job.affinity_specifier = key_map.get(source_key)
+        return job
 
     def tick(self) -> Job | None:
         job = self.get_next_job()
         if not job:
             return None
-        job.ensure_exists()
-        if job.status == JobStatus.CANCELLED:  # Simply skip running cancelled jobs
+
+        with self.redis.pipeline(transaction=False) as p:
+            # Grab the data we need in a single pipeline.
+            p.hget(job.redis_key, "status")
+            p.hexists(job.redis_key, "acquired")
+            p.hget(job.redis_key, "affinity")
+            status_raw, acquired, affinity_raw = p.execute()
+        job._cache_affinity(affinity_raw)
+
+        if status_raw is None:
+            self.log.warning("skipping phantom of vanished job %s", job.id)
             return None
-        runner = self.job_runner_class(worker=self, job=job)
-        runner.run()
+
+        if JobStatus(status_raw.decode()) == JobStatus.CANCELLED:
+            return None
+
+        if acquired:
+            self.log.debug("skipping phantom of already-run job %s", job.id)
+            return None
+
+        try:
+            runner = self.job_runner_class(worker=self, job=job)
+            runner.run()
+        except NoSuchJob:  # Job hash expired? Phantom.
+            self.log.debug("skipping phantom of vanished job %s", job.id)
+            return None
+        except AlreadyAcquired:  # Same-instant pop, so phantom for us.
+            self.log.debug("skipping phantom of already-acquired job %s", job.id)
+            return None
+
+        # Done, we're now warm for this.
+        now = time.time()
+        for specifier in job.affinity:
+            self.warm_specifiers[specifier] = now
+
         return job
 
     def loop(self) -> None:  # pragma: no cover

--- a/minique_tests/test_affinity.py
+++ b/minique_tests/test_affinity.py
@@ -1,0 +1,389 @@
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING
+
+from minique.api import (
+    clean_affinity_sub_queues,
+    enqueue,
+    enqueue_priority,
+)
+from minique.consts import QUEUE_KEY_PREFIX
+from minique.enums import JobStatus
+from minique.models.priority_queue import PriorityQueue
+from minique.models.queue import Queue
+from minique.utils.affinity import get_affinity_queue_name, get_affinity_sub_queue_names
+from minique_tests.worker import TestWorker
+
+if TYPE_CHECKING:
+    from minique.types import RedisClient
+
+
+def _list_ids(redis: RedisClient, key: str) -> list[str]:
+    return [v.decode() for v in redis.lrange(key, 0, -1)]
+
+
+def test_dual_write(redis: RedisClient, random_queue_name: str) -> None:
+    job = enqueue(
+        redis,
+        random_queue_name,
+        "minique_tests.jobs.sum_positive_values",
+        affinity=["x"],
+    )
+    assert job.affinity == ["x"]
+
+    base_key = Queue(redis, random_queue_name).redis_key
+    sub_key = QUEUE_KEY_PREFIX + get_affinity_queue_name(random_queue_name, "x")
+    # The job id is present in both the base queue and the affinity sub-queue.
+    assert _list_ids(redis, base_key) == [job.id]
+    assert _list_ids(redis, sub_key) == [job.id]
+
+
+def test_no_affinity_leaves_no_extra_keys(
+    redis: RedisClient, random_queue_name: str
+) -> None:
+    job = enqueue(redis, random_queue_name, "minique_tests.jobs.sum_positive_values")
+    assert job.affinity == []
+    assert list(get_affinity_sub_queue_names(redis, random_queue_name)) == []
+
+
+def test_affinity_is_deduplicated(redis: RedisClient, random_queue_name: str) -> None:
+    job = enqueue(
+        redis,
+        random_queue_name,
+        "minique_tests.jobs.sum_positive_values",
+        affinity=["x", "x", "", "y"],
+    )
+    # Empty specifiers dropped, duplicates collapsed, order preserved.
+    assert job.affinity == ["x", "y"]
+    assert sorted(get_affinity_sub_queue_names(redis, random_queue_name)) == sorted(
+        [
+            get_affinity_queue_name(random_queue_name, "x"),
+            get_affinity_queue_name(random_queue_name, "y"),
+        ]
+    )
+
+
+def test_warm_worker_key_order(redis: RedisClient, random_queue_name: str) -> None:
+    worker = TestWorker.for_queue_names(redis, random_queue_name)
+    base_key = Queue(redis, random_queue_name).redis_key
+
+    # Cold worker: byte-for-byte the plain base-queue key list (no warm specifier).
+    assert worker.get_blpop_keys() == {base_key: None}
+
+    # Warm worker: the matching affinity sub-queue is listed ahead of the base queue,
+    # mapped to the specifier it serves.
+    worker.warm_specifiers["x"] = time.time()
+    sub_key = QUEUE_KEY_PREFIX + get_affinity_queue_name(random_queue_name, "x")
+    assert worker.get_blpop_keys() == {sub_key: "x", base_key: None}
+    # Insertion order is BLPOP priority order: sub-queue before base queue.
+    assert list(worker.get_blpop_keys()) == [sub_key, base_key]
+
+
+def test_warm_specifiers_prune_and_cap(redis: RedisClient) -> None:
+    worker = TestWorker.for_queue_names(redis, "q")
+    worker.affinity_window = 100
+    worker.affinity_max_specifiers = 2
+
+    now = time.time()
+    worker.warm_specifiers = {
+        "old": now - 1000,  # past the window -> pruned
+        "a": now - 30,
+        "b": now - 20,
+        "c": now - 10,  # most recent
+    }
+    # Pruned to within-window, capped to 2, most-recent first.
+    assert worker.get_current_warm_specifiers() == ["c", "b"]
+    assert "old" not in worker.warm_specifiers
+    # The cap applies to the backing dict too, not just the returned view, so the warm
+    # set can't grow (and be re-sorted) without bound between ticks.
+    assert set(worker.warm_specifiers) == {"c", "b"}
+
+
+def test_worker_becomes_warm_after_running(
+    redis: RedisClient, random_queue_name: str
+) -> None:
+    worker = TestWorker.for_queue_names(redis, random_queue_name)
+    enqueue(
+        redis,
+        random_queue_name,
+        "minique_tests.jobs.sum_positive_values",
+        kwargs={"a": 1, "b": 2},
+        affinity=["x"],
+    )
+    job = worker.tick()
+    assert job is not None and job.status == JobStatus.SUCCESS
+    # Running an x-job makes the worker warm for x.
+    assert worker.get_current_warm_specifiers() == ["x"]
+
+
+def test_warm_worker_prefers_sub_queue(
+    redis: RedisClient, random_queue_name: str
+) -> None:
+    worker = TestWorker.for_queue_names(redis, random_queue_name)
+    worker.warm_specifiers["x"] = time.time()
+
+    job = enqueue(
+        redis,
+        random_queue_name,
+        "minique_tests.jobs.sum_positive_values",
+        kwargs={"a": 1, "b": 2},
+        affinity=["x"],
+    )
+    base_key = Queue(redis, random_queue_name).redis_key
+    sub_key = QUEUE_KEY_PREFIX + get_affinity_queue_name(random_queue_name, "x")
+
+    # The warm worker pops the sub-queue copy and runs the job; acquiring it drains the
+    # sibling base copy, so no phantom is left on the base queue to accumulate.
+    ran = worker.tick()
+    assert ran == job and job.status == JobStatus.SUCCESS
+    assert _list_ids(redis, sub_key) == []
+    assert _list_ids(redis, base_key) == []
+    # Nothing left to pick up; no double-run.
+    assert worker.tick() is None
+
+
+def test_job_reports_affinity_source(
+    redis: RedisClient, random_queue_name: str
+) -> None:
+    # A warm worker that pops a job off an affinity sub-queue exposes which specifier it
+    # matched, so a JobRunner subclass can surface that it served warm work.
+    worker = TestWorker.for_queue_names(redis, random_queue_name)
+    worker.warm_specifiers["x"] = time.time()
+    sub_key = QUEUE_KEY_PREFIX + get_affinity_queue_name(random_queue_name, "x")
+
+    enqueue(
+        redis,
+        random_queue_name,
+        "minique_tests.jobs.sum_positive_values",
+        kwargs={"a": 1, "b": 2},
+        affinity=["x"],
+    )
+    job = worker.tick()
+    assert job is not None
+    assert job.source_queue_key == sub_key
+    assert job.affinity_specifier == "x"
+
+
+def test_job_reports_base_queue_source_when_cold(
+    redis: RedisClient, random_queue_name: str
+) -> None:
+    # A cold worker pops the base copy: source is the base queue and there's no specifier.
+    worker = TestWorker.for_queue_names(redis, random_queue_name)
+    base_key = Queue(redis, random_queue_name).redis_key
+
+    enqueue(
+        redis,
+        random_queue_name,
+        "minique_tests.jobs.sum_positive_values",
+        kwargs={"a": 1, "b": 2},
+        affinity=["x"],
+    )
+    job = worker.tick()
+    assert job is not None
+    assert job.source_queue_key == base_key
+    assert job.affinity_specifier is None
+
+
+def test_base_queue_does_not_accumulate_phantoms(
+    redis: RedisClient, random_queue_name: str
+) -> None:
+    # Regression: a warm worker draining many affine jobs via their sub-queues must not
+    # leave a growing pile of phantom copies on the base queue.
+    worker = TestWorker.for_queue_names(redis, random_queue_name)
+    worker.warm_specifiers["x"] = time.time()
+    base_key = Queue(redis, random_queue_name).redis_key
+    sub_key = QUEUE_KEY_PREFIX + get_affinity_queue_name(random_queue_name, "x")
+
+    for _ in range(5):
+        enqueue(
+            redis,
+            random_queue_name,
+            "minique_tests.jobs.sum_positive_values",
+            kwargs={"a": 1, "b": 2},
+            affinity=["x"],
+        )
+    for _ in range(5):
+        assert worker.tick() is not None
+
+    # Every copy of every job was drained at acquisition: nothing lingers anywhere.
+    assert _list_ids(redis, base_key) == []
+    assert _list_ids(redis, sub_key) == []
+
+
+def test_dequeue_removes_affinity_copies(
+    redis: RedisClient, random_queue_name: str
+) -> None:
+    job = enqueue(
+        redis,
+        random_queue_name,
+        "minique_tests.jobs.sum_positive_values",
+        kwargs={"a": 1, "b": 2},
+        affinity=["x"],
+    )
+    base_key = Queue(redis, random_queue_name).redis_key
+    sub_key = QUEUE_KEY_PREFIX + get_affinity_queue_name(random_queue_name, "x")
+
+    # dequeue() removes the job from the base queue AND its affinity sub-queue(s)...
+    assert job.dequeue()
+    assert _list_ids(redis, base_key) == []
+    assert _list_ids(redis, sub_key) == []
+    # ...so a warm worker can no longer pop it from the sub-queue.
+    worker = TestWorker.for_queue_names(redis, random_queue_name)
+    worker.warm_specifiers["x"] = time.time()
+    assert worker.tick() is None
+
+
+def test_clear_also_clears_affinity_sub_queues(
+    redis: RedisClient, random_queue_name: str
+) -> None:
+    job = enqueue(
+        redis,
+        random_queue_name,
+        "minique_tests.jobs.sum_positive_values",
+        kwargs={"a": 1, "b": 2},
+        affinity=["x"],
+    )
+    base_key = Queue(redis, random_queue_name).redis_key
+    sub_key = QUEUE_KEY_PREFIX + get_affinity_queue_name(random_queue_name, "x")
+    assert _list_ids(redis, sub_key) == [job.id]
+
+    Queue(redis, random_queue_name).clear()
+
+    # Neither the base queue nor the affinity sub-queue retains runnable work...
+    assert _list_ids(redis, base_key) == []
+    assert _list_ids(redis, sub_key) == []
+    # ...so a warm worker finds nothing to run.
+    worker = TestWorker.for_queue_names(redis, random_queue_name)
+    worker.warm_specifiers["x"] = time.time()
+    assert worker.tick() is None
+
+
+def test_clear_priority_queue_clears_affinity_sub_queue_prio_hashes(
+    redis: RedisClient, random_queue_name: str
+) -> None:
+    enqueue_priority(
+        redis,
+        random_queue_name,
+        "minique_tests.jobs.sum_positive_values",
+        kwargs={"a": 1, "b": 2},
+        priority=5,
+        affinity=["x"],
+    )
+    sub_key = QUEUE_KEY_PREFIX + get_affinity_queue_name(random_queue_name, "x")
+    sub_prio_key = f"{sub_key}prio"
+    base_prio_key = f"{QUEUE_KEY_PREFIX}{random_queue_name}prio"
+    assert redis.exists(sub_key) and redis.exists(sub_prio_key)
+    assert redis.exists(base_prio_key)
+
+    PriorityQueue(redis, random_queue_name).clear()
+    assert not redis.exists(sub_key)
+    assert not redis.exists(sub_prio_key)
+    # The base queue's own `…prio` hash has no affinity infix, so it must be cleared
+    # explicitly rather than relying on the sub-queue glob (which can't match it).
+    assert not redis.exists(base_prio_key)
+
+
+def test_multi_queue_key_order_groups_by_queue(redis: RedisClient) -> None:
+    # Queue-order-as-priority must be preserved: all of q1 (its affinity sub-queues
+    # included) is preferred over anything in q2.
+    worker = TestWorker.for_queue_names(redis, ["q1", "q2"])
+    worker.warm_specifiers["x"] = time.time()
+
+    q1 = Queue(redis, "q1").redis_key
+    q2 = Queue(redis, "q2").redis_key
+    q1x = QUEUE_KEY_PREFIX + get_affinity_queue_name("q1", "x")
+    q2x = QUEUE_KEY_PREFIX + get_affinity_queue_name("q2", "x")
+    assert list(worker.get_blpop_keys()) == [q1x, q1, q2x, q2]
+
+
+def test_cold_worker_serves_base_copy(
+    redis: RedisClient, random_queue_name: str
+) -> None:
+    # An affine job must be reachable by a worker that is not warm for its specifier.
+    job = enqueue(
+        redis,
+        random_queue_name,
+        "minique_tests.jobs.sum_positive_values",
+        kwargs={"a": 1, "b": 2},
+        affinity=["x"],
+    )
+    cold = TestWorker.for_queue_names(redis, random_queue_name)
+    assert not cold.get_current_warm_specifiers()
+    ran = cold.tick()
+    assert ran == job and job.status == JobStatus.SUCCESS
+
+
+def test_priority_affinity_sub_queue_and_cleanup(
+    redis: RedisClient, random_queue_name: str
+) -> None:
+    job = enqueue_priority(
+        redis,
+        random_queue_name,
+        "minique_tests.jobs.sum_positive_values",
+        kwargs={"a": 1, "b": 2},
+        priority=5,
+        affinity=["x"],
+    )
+    sub_name = get_affinity_queue_name(random_queue_name, "x")
+    sub_key = QUEUE_KEY_PREFIX + sub_name
+    sub_prio_key = f"{sub_key}prio"
+    # The sub-queue is a priority sub-queue with its own priority lookup hash.
+    assert _list_ids(redis, sub_key) == [job.id]
+    assert redis.hget(sub_prio_key, job.id) == b"5"
+
+    # Simulate the job hash having expired, leaving a phantom id behind in the sub-queue.
+    redis.delete(job.redis_key)
+    removed = clean_affinity_sub_queues(redis, random_queue_name, priority=True)
+    assert removed == 1
+    # The phantom id (and its now-empty list and prio hash) are gone.
+    assert not redis.exists(sub_key)
+    assert not redis.exists(sub_prio_key)
+
+
+def test_clean_affinity_sub_queues_removes_orphaned_prio_hash(
+    redis: RedisClient, random_queue_name: str
+) -> None:
+    enqueue_priority(
+        redis,
+        random_queue_name,
+        "minique_tests.jobs.sum_positive_values",
+        kwargs={"a": 1, "b": 2},
+        priority=5,
+        affinity=["x"],
+    )
+    sub_key = QUEUE_KEY_PREFIX + get_affinity_queue_name(random_queue_name, "x")
+    sub_prio_key = f"{sub_key}prio"
+    # Drain the list directly (as a BLPOP would), orphaning the prio lookup hash.
+    redis.delete(sub_key)
+    assert redis.exists(sub_prio_key)
+
+    removed = clean_affinity_sub_queues(redis, random_queue_name, priority=True)
+    assert removed == 1
+    assert not redis.exists(sub_prio_key)
+
+
+def test_priority_sub_queue_prio_hash_does_not_leak_while_flowing(
+    redis: RedisClient, random_queue_name: str
+) -> None:
+    # Regression: acquiring a priority affine job must drain its prio-hash entry from the
+    # affinity sub-queue, so a busy specifier's `…prio` hash stays bounded.
+    worker = TestWorker.for_queue_names(redis, random_queue_name)
+    worker.warm_specifiers["x"] = time.time()
+    sub_prio_key = (
+        QUEUE_KEY_PREFIX + get_affinity_queue_name(random_queue_name, "x") + "prio"
+    )
+
+    for _ in range(5):
+        enqueue_priority(
+            redis,
+            random_queue_name,
+            "minique_tests.jobs.sum_positive_values",
+            kwargs={"a": 1, "b": 2},
+            priority=5,
+            affinity=["x"],
+        )
+        assert worker.tick() is not None
+
+    # Every acquired job removed its own entry; nothing accumulated.
+    assert redis.hlen(sub_prio_key) == 0

--- a/minique_tests/test_errors.py
+++ b/minique_tests/test_errors.py
@@ -7,7 +7,7 @@ import pytest
 
 from minique.api import enqueue
 from minique.enums import JobStatus
-from minique.excs import AlreadyAcquired, DuplicateJob, NoSuchJob
+from minique.excs import DuplicateJob
 from minique.models.queue import Queue
 from minique_tests.jobs import job_with_unjsonable_retval
 from minique_tests.worker import TestWorker
@@ -64,8 +64,8 @@ def test_disappeared_job(redis: RedisClient, random_queue_name: str):
     assert Queue(redis, random_queue_name).length == 1
     time.sleep(2)
     worker = TestWorker.for_queue_names(redis, random_queue_name)
-    with pytest.raises(NoSuchJob):  # It's expired :(
-        worker.tick()
+    # The job hash has expired; the lingering queue entry is a phantom, quietly skipped.
+    assert worker.tick() is None
 
 
 def test_rerun_done_job(redis: RedisClient, random_queue_name: str, sentry_event_calls):
@@ -77,9 +77,10 @@ def test_rerun_done_job(redis: RedisClient, random_queue_name: str, sentry_event
     # but let's re-enqueue the job anyway by touching some internals:
     queue = Queue(redis, random_queue_name)
     redis.rpush(queue.redis_key, job.id)
-    with pytest.raises(AlreadyAcquired):
-        worker.tick()
-    check_sentry_event_calls(sentry_event_calls, 2)
+    # A re-enqueued, already-finished job is a phantom: skipped quietly, not re-run.
+    assert worker.tick() is None
+    # Only the original run produced an (error) event; the phantom skip produced none.
+    check_sentry_event_calls(sentry_event_calls, 1)
 
 
 def test_duplicate_names(redis: RedisClient, random_queue_name: str):


### PR DESCRIPTION
Let jobs carry opaque affinity markers so same-data jobs preferentially run on the same worker, amplifying per-node input caching (etc.) without changing how unmarked work behaves.
